### PR TITLE
Explicit conversion to string for the toContain matcher

### DIFF
--- a/spec/general/runtimeSpec.js
+++ b/spec/general/runtimeSpec.js
@@ -35,6 +35,6 @@ describe('The runtime', function() {
 		const scriptRunError = await testEnv.runLemonScript(scriptSource)
 			.catch(error => error);
 		
-		expect(scriptRunError).toContain('ReferenceError: methodThatDoesNotExist is not defined');
+		expect(scriptRunError.toString()).toContain('ReferenceError: methodThatDoesNotExist is not defined');
 	});
 });


### PR DESCRIPTION
This test was failing for me on a fresh clone. The `scriptRunError` variable was coming back as an object type, which couldn't be used in the `.toContain` matcher. By explicitly casting it to a string, we are able to use Jasmine's matcher.

For reference, I'm running node v15.12.0 on MacOS 11.2.3.
