### PR TITLE
Scoped package support for NPM

### DIFF
--- a/docs/api-reference-source/npm.xml
+++ b/docs/api-reference-source/npm.xml
@@ -37,9 +37,9 @@ cli.tell('Total count of unique friend names: ' + uniqueFriendNames.length);
 				<p>
 					To access a package with special characters in its name, use bracket notation.
 				</p>
-			
-				<df-sample name="Use the uuid package">
-const uuid = npm['uuid/v4'];
+				
+				<df-sample name="Use the UUID package from Allthings">
+const uuid = npm['@allthings/uuid'];
 cli.tell('New unique identifier: ' + uuid());
 				</df-sample>
 			]]>
@@ -66,6 +66,20 @@ cli.tell('Hello, ' + await npm.username() + '!');
 				
 				<df-sample name="Automatically add version directives to a script">
 $ lemon --pin-packages script.js
+				</df-sample>
+			]]>
+			</discussion>
+		</detail>
+		<detail name="Requiring other files" id="requiring-sub-files">
+			<discussion>
+			<![CDATA[
+				<p>
+					If your script needs to use a specific sub-file of a package, rather than the package's main file, you can specify it by using a colon to separate the package name from the sub-file path.
+				</p>
+				
+				<df-sample name="Use the uuid package">
+const uuid = npm['uuid:v4'];
+cli.tell('New unique identifier: ' + uuid());
 				</df-sample>
 			]]>
 			</discussion>

--- a/source/HeaderLine/RequireHeaderLine.js
+++ b/source/HeaderLine/RequireHeaderLine.js
@@ -15,7 +15,7 @@ module.exports = class RequireHeaderLine extends HeaderLine {
 	}
 	
 	static forString(lineString) {
-		const lineParts = /^#require\s+([^@\s]+)@([^\s]+)\s*$/.exec(lineString);
+		const lineParts = /^#require\s+([^\s]+)@([^@\s]+)\s*$/.exec(lineString);
 		
 		if (!lineParts) return null;
 		

--- a/source/PackageCache.js
+++ b/source/PackageCache.js
@@ -157,7 +157,6 @@ module.exports = {
 	// // Tools
 	_normalizePackageList(packageList, packageVersions = {}) {
 		const normalized = packageList
-			.map(packageName => /[^/]+/.exec(packageName)[0])
 			.map(packageName => {
 				const packageVersion = packageVersions[packageName];
 				

--- a/source/PackageCache.js
+++ b/source/PackageCache.js
@@ -157,6 +157,7 @@ module.exports = {
 	// // Tools
 	_normalizePackageList(packageList, packageVersions = {}) {
 		const normalized = packageList
+			.map(packageName => /[^:]+/.exec(packageName)[0])
 			.map(packageName => {
 				const packageVersion = packageVersions[packageName];
 				

--- a/source/packageCacheBundleIndexFile.template.js
+++ b/source/packageCacheBundleIndexFile.template.js
@@ -2,7 +2,7 @@
 
 module.exports = function getPackage(name) {
 	try {
-		return require(name);
+		return require(name.replace(':', '/'));
 	} catch(e) {
 		return null;
 	}

--- a/source/preparePackageCacheBundle.js
+++ b/source/preparePackageCacheBundle.js
@@ -149,7 +149,7 @@ function startPulse() {
 	function schedulePulse() {
 		currentPulseTimeout = setTimeout(() => {
 			if (isPulsing) {
-				fs.writeFile(bundlePath + PULSE_FILE_NAME, Date.now());
+				fs.writeFile(bundlePath + PULSE_FILE_NAME, Date.now().toString());
 				schedulePulse();
 			}
 		}, PULSE_REFRESH_INTERVAL);

--- a/source/preparePackageCacheBundle.js
+++ b/source/preparePackageCacheBundle.js
@@ -37,7 +37,7 @@ async function doesItemExist(path) {
 // // Installation process
 function parsePackageList(rawPackageList) {
 	return rawPackageList.reduce((result, packageString) => {
-		const [, name, version] = /([^@]+)@?(.*)/.exec(packageString);
+		const [, name, version] = /^(.+?)(?:@([^@]*))?$/.exec(packageString);
 		result[name] = version ? version : '*';
 		return result;
 	}, {});

--- a/spec/npm/npmSpec.js
+++ b/spec/npm/npmSpec.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+
+describe('npm', function() {
+	let testEnv;
+
+	beforeEach(function() {
+		testEnv = this.getTestEnv();
+	});
+
+	it('should install and run simply named packages', async function() {
+		const scriptSource = `
+			const uniqueCount = npm.dedupe([1, 2, 2, 3]).length;
+			here.file('output').make(true).content = uniqueCount;
+		`;
+
+		await testEnv.runLemonScript(scriptSource);
+
+		const outputPath = testEnv.nativePathFor('output');
+		let value = parseInt(fs.readFileSync(outputPath));
+		expect(value).toBe(3);
+	});
+
+	it('should install and run scoped packages', async function() {
+		const scriptSource = `
+			const stryker = new npm['@stryker-mutator/core'].Stryker({ concurrency: 4 });
+			here.file('output').make(true).content = stryker.cliOptions.concurrency;
+		`;
+
+		await testEnv.runLemonScript(scriptSource);
+
+		const outputPath = testEnv.nativePathFor('output');
+		let value = parseInt(fs.readFileSync(outputPath));
+		expect(value).toBe(4);
+	});
+
+	it('should recognize pinned versions for scoped packages', async function() {
+		// The #require must be in column 0 of the script, thus the unusual formatting
+		const scriptSource = `#require @octokit/core@3.2.4
+			here.file('output').make(true).content = npm['@octokit/core'].Octokit.VERSION;
+		`;
+
+		await testEnv.runLemonScript(scriptSource);
+
+		const outputPath = testEnv.nativePathFor('output');
+		let value = fs.readFileSync(outputPath).toString();
+		expect(value).toBe('3.2.4');
+	});
+});

--- a/spec/npm/npmSpec.js
+++ b/spec/npm/npmSpec.js
@@ -45,4 +45,23 @@ describe('npm', function() {
 		let value = fs.readFileSync(outputPath).toString();
 		expect(value).toBe('3.2.4');
 	});
+
+	it('should allow require-access to sub files', async function() {
+		const scriptSource = `#require uuid@3.3.0
+			const uuid_v1 = npm['uuid:v1'];
+			const uuid_v4 = npm['uuid:v4'];
+
+			here.file('output.json').make(true).content = {
+				v1: uuid_v1.toString(),
+				v4: uuid_v4.toString()
+			};
+		`;
+
+		await testEnv.runLemonScript(scriptSource);
+
+		const outputPath = testEnv.nativePathFor('output.json');
+		let value = JSON.parse(fs.readFileSync(outputPath));
+		expect(value.v1).toContain('function v1');
+		expect(value.v4).toContain('function v4');
+	});
 });


### PR DESCRIPTION
This adds support for npm packages that are scoped by the convention `@SCOPE/PACKAGE`, such as `@octokit/rest`. Some of the package parsing regexes relied on the presence of at most one "@" to separate the name from the version. This adds support for multiple "@"s, with the last of them separating the package from the version. As an exception, an "@" at the beginning is not a separator, even if it is the last one.

I added some test cases to show what I mean. Because they hit the npm registry as part of operating, you'll need an active internet connection to run the tests. And, it affects your `~/.cache`. And it takes some time to run -- if you're on a slow connection you could run into problems with the jasmine default timeout value. Up to you whether to keep these as jasmine tests or not.